### PR TITLE
Support button will open default mail client.

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -31,7 +31,7 @@ describe("Sidebar Navigation", () => {
         .should("have.attr", "href", "/dashboard/settings");
     });
 
-    it.only("is collapsible", () => {
+    it("is collapsible", () => {
       cy.get("nav")
         .contains("Collapse")
         .find("img")
@@ -50,6 +50,23 @@ describe("Sidebar Navigation", () => {
 
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
+    });
+
+    it.only("opens a user's default email client when the Support button is clicked", () => {
+      const windowOpenStub = cy.stub().as("windowOpenStub");
+
+      cy.window().then((win) => {
+        cy.stub(win, "open").callsFake(windowOpenStub);
+      });
+
+      cy.get("nav")
+        .contains("Support")
+        .click()
+        .then(() => {
+          expect(windowOpenStub).to.be.calledWith(
+            "mailto:support@prolog-app.com?subject=Support Request: ",
+          );
+        });
     });
   });
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -8,6 +8,13 @@ import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
 import styles from "./sidebar-navigation.module.scss";
 
+function openEmailClient() {
+  const supportSubject = "Support Request: ";
+  const supportEmail = "support@prolog-app.com";
+
+  window.open(`mailto:${supportEmail}?subject=${supportSubject}`);
+}
+
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
   { text: "Issues", iconSrc: "/icons/issues.svg", href: Routes.issues },
@@ -83,8 +90,9 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={openEmailClient}
             />
+
             <MenuItemButton
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"


### PR DESCRIPTION
I could've turned the `MenuItemButton` into a `MenuItemLink` but the `href` attribute wouldn't be as cut and dry to use because `MenuItemLink` only appends to the base url. Seemed like a headache so I ended up just sticking with `MenuItemButton`.

Open to suggestions!