### PR TITLE
Issues display proper no. of events and no. of users.

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -23,7 +23,6 @@ describe("Issue List", () => {
 
     // wait for request to resolve
     cy.wait(["@getProjects", "@getIssuesPage1"]);
-    cy.wait(500);
 
     // set button aliases
     cy.get("button").contains("Previous").as("prev-button");
@@ -36,16 +35,35 @@ describe("Issue List", () => {
     });
 
     it("renders the issues", () => {
+      // lets make sure we're on page 1
+      cy.contains("Page 1 of 3");
+
+      const issues = mockIssues1.items;
+
       cy.get("main")
         .find("tbody")
         .find("tr")
         .each(($el, index) => {
-          const issue = mockIssues1.items[index];
+          const issue = issues[index];
           const firstLineOfStackTrace = issue.stack.split("\n")[1].trim();
-          cy.wrap($el).contains(issue.name);
-          cy.wrap($el).contains(issue.message);
-          cy.wrap($el).contains(issue.numEvents);
-          cy.wrap($el).contains(firstLineOfStackTrace);
+
+          cy.wrap($el).get('[data-cy="issues-name"]').contains(issue.name);
+
+          cy.wrap($el)
+            .get('[data-cy="issues-message"]')
+            .contains(issue.message);
+
+          cy.wrap($el)
+            .get('[data-cy="issues-numEvents"]')
+            .contains(issue.numEvents);
+
+          cy.wrap($el)
+            .get('[data-cy="issues-numUsers"]')
+            .contains(issue.numUsers);
+
+          cy.wrap($el)
+            .get('[data-cy="issues-stackTrace"]')
+            .contains(firstLineOfStackTrace);
         });
     });
 
@@ -79,7 +97,6 @@ describe("Issue List", () => {
 
       cy.reload();
       cy.wait(["@getProjects", "@getIssuesPage2"]);
-      cy.wait(1500);
       cy.contains("Page 2 of 3");
     });
   });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -30,20 +30,26 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
           alt={projectLanguage}
         />
         <div>
-          <div className={styles.errorTypeAndMessage}>
-            <span className={styles.errorType}>{name}:&nbsp;</span>
+          <div className={styles.errorTypeAndMessage} data-cy="issues-message">
+            <span className={styles.errorType} data-cy="issues-name">
+              {name}:&nbsp;
+            </span>
             {message}
           </div>
-          <div>{firstLineOfStackTrace}</div>
+          <div data-cy="issues-stackTrace">{firstLineOfStackTrace}</div>
         </div>
       </td>
-      <td className={styles.cell}>
+      <td className={styles.cell} data-cy="issues-level">
         <Badge color={levelColors[level]} size={BadgeSize.sm}>
           {capitalize(level)}
         </Badge>
       </td>
-      <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell} data-cy="issues-numEvents">
+        {numEvents}
+      </td>
+      <td className={styles.cell} data-cy="issues-numUsers">
+        {numUsers}
+      </td>
     </tr>
   );
 }


### PR DESCRIPTION
I also updated the table cells with `data-cy=` tags so the updated test targets those specific cells to check if the proper data is in them.

I removed some `cy.wait(...)` lines and it seems like the tests retry just as much as with that code still there so... I dunno? Any reason not to remove them?